### PR TITLE
feat: support cert site

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ proxyfor can decrypt encrypted traffic on the fly, as long as the client trusts 
 
 The proxyfor CA cert is located in `~/.proxyfor` after it has been generated at the first start of proxyfor.
 
-By far the easiest way to install the proxyfor CA certificate is to use the built-in certificate installation app.
+By far the easiest way to [install the proxyfor CA certificate](./assets/install-certificate.md) is to use the built-in certificate installation app.
 To do this, start mitmproxy and configure your target device with the correct proxy settings.
 Now start a browser on the device, and visit the magic domain [proxyfor.local](http://proxyfor.local).
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ proxyfor can decrypt encrypted traffic on the fly, as long as the client trusts 
 
 The proxyfor CA cert is located in `~/.proxyfor` after it has been generated at the first start of proxyfor.
 
+By far the easiest way to install the proxyfor CA certificate is to use the built-in certificate installation app.
+To do this, start mitmproxy and configure your target device with the correct proxy settings.
+Now start a browser on the device, and visit the magic domain [proxyfor.local](http://proxyfor.local).
+
+![proxyfor.local](https://github.com/sigoden/proxyfor/assets/4012553/a5276872-8ab1-4794-9e97-ac7038ca5e4a)
+
 ## License
 
 Copyright (c) 2024-∞ proxyfor-developers.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ proxyfor can decrypt encrypted traffic on the fly, as long as the client trusts 
 The proxyfor CA cert is located in `~/.proxyfor` after it has been generated at the first start of proxyfor.
 
 By far the easiest way to [install the proxyfor CA certificate](./assets/install-certificate.md) is to use the built-in certificate installation app.
-To do this, start mitmproxy and configure your target device with the correct proxy settings.
+To do this, start proxyfor and configure your target device with the correct proxy settings.
 Now start a browser on the device, and visit the magic domain [proxyfor.local](http://proxyfor.local).
 
 ![proxyfor.local](https://github.com/sigoden/proxyfor/assets/4012553/a5276872-8ab1-4794-9e97-ac7038ca5e4a)

--- a/assets/install-certificate.html
+++ b/assets/install-certificate.html
@@ -32,7 +32,7 @@ summary:before {
 href="http://proxyfor.local/proxyfor-ca-cert.cer">proxyfor-ca-cert.cer</a></p>
 <h3 id="manual-installation">Manual Installation</h3>
 <ol type="1">
-<li>Double-click the cer file to start the import wizard.</li>
+<li>Double-click the CER file to start the import wizard.</li>
 <li>Select a certificate store location. This determines who will trust
 the certificate – only the current Windows user or everyone on the
 machine. Click Next.</li>

--- a/assets/install-certificate.html
+++ b/assets/install-certificate.html
@@ -1,0 +1,149 @@
+<h1 id="install-proxyfors-certificate-authority">Install proxyfor’s
+Certificate Authority</h1>
+<head>
+    <title>proxyfor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<style>
+summary {
+    display: flex;
+    align-items: center;
+}
+summary * {
+    margin: 0;
+    padding: 0;
+}
+
+summary::-webkit-details-marker {
+    display: none;
+}
+
+summary:before {
+    content: '►';
+    display: inline-block;
+    margin-right: 5px;
+}
+</style>
+<details>
+<summary>
+<h2 id="windows">Windows</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.cer">proxyfor-ca-cert.cer</a></p>
+<h3 id="manual-installation">Manual Installation</h3>
+<ol type="1">
+<li>Double-click the cer file to start the import wizard.</li>
+<li>Select a certificate store location. This determines who will trust
+the certificate – only the current Windows user or everyone on the
+machine. Click Next.</li>
+<li>Click Next again.</li>
+<li>Leave Password blank and click Next.</li>
+<li><strong>Select Place all certificates in the following
+store</strong>, then click Browse, and select Trusted Root Certification
+Authorities.<br />
+Click OK and Next.</li>
+<li>Click Finish.</li>
+<li>Click Yes to confirm the warning dialog.</li>
+</ol>
+<h3 id="automated-installation">Automated Installation</h3>
+<ol type="1">
+<li>Run <code>certutil.exe -addstore root proxyfor-ca-cert.cer</code>
+(<a
+href="https://technet.microsoft.com/en-us/library/cc732443.aspx">details</a>).</li>
+</ol>
+</details>
+<details>
+<summary>
+<h2 id="linux">Linux</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.pem">proxyfor-ca-cert.pem</a></p>
+<h3 id="ubuntudebian">Ubuntu/Debian</h3>
+<ol type="1">
+<li><code>mv proxyfor-ca-cert.pem /usr/local/share/ca-certificates/proxyfor.crt</code></li>
+<li><code>sudo update-ca-certificates</code></li>
+</ol>
+<h3 id="fedora">Fedora</h3>
+<ol type="1">
+<li><code>mv proxyfor-ca-cert.pem /etc/pki/ca-trust/source/anchors/</code></li>
+<li><code>sudo update-ca-trust</code></li>
+</ol>
+</details>
+<details>
+<summary>
+<h2 id="macos">macOS</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.pem">proxyfor-ca-cert.pem</a></p>
+<h3 id="manual-installation-1">Manual Installation</h3>
+<ol type="1">
+<li>Double-click the PEM file to open the Keychain Access
+application.</li>
+<li>Locate the new certificate “proxyfor” in the list and double-click
+it.</li>
+<li>Change Secure Socket Layer (SSL) to Always Trust.</li>
+<li>Close the dialog window and enter your password if prompted.</li>
+</ol>
+<h3 id="automated-installation-1">Automated Installation</h3>
+<ol type="1">
+<li><code>sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain proxyfor-ca-cert.pem</code></li>
+</ol>
+</details>
+<details>
+<summary>
+<h2 id="ios">iOS</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.pem">proxyfor-ca-cert.pem</a></p>
+<h3 id="ios-13">iOS 13+</h3>
+<ol type="1">
+<li>Use Safari to download the certificate. Other browsers may not open
+the proper installation prompt.</li>
+<li>Install the new Profile (Settings -&gt; General -&gt; VPN &amp;
+Device Management).</li>
+<li><strong>Important: Go to Settings -&gt; General -&gt; About -&gt;
+Certificate Trust Settings.</strong> Toggle proxyfor to ON.</li>
+</ol>
+</details>
+<details>
+<summary>
+<h2 id="android">Android</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.cer">proxyfor-ca-cert.cer</a></p>
+<h3 id="android-10">Android 10+</h3>
+<ol type="1">
+<li>Open the downloaded CER file.</li>
+<li>Enter proxyfor (or anything else) as the certificate name.</li>
+<li>For credential use, select VPN and apps.</li>
+<li>Click OK.</li>
+</ol>
+<p>Some Android distributions require you to install the certificate via
+Settings -&gt; Security -&gt; Advanced -&gt; Encryption and credentials
+-&gt; Install a certificate -&gt; CA certificate (or similar)
+instead.</p>
+<p><strong>Warning:</strong> Apps that target Android API Level 24
+(introduced in 2016) and above only accept certificates from the system
+trust store (<a
+href="https://github.com/proxyfor/proxyfor/issues/2054">#2054</a>).
+User-added CAs are not accepted unless the application manually opts in.
+Except for browsers, you need to patch most apps manually (<a
+href="https://developer.android.com/training/articles/security-config">Android
+network security config</a>).</p>
+<p>Alternatively, if you have rooted the device and have Magisk
+installed, you can install <a href="/cert/magisk">this Magisk module</a>
+via the Magisk Manager app.</p>
+</details>
+<details>
+<summary>
+<h2 id="firefox">Firefox</h2>
+</summary>
+<p><a
+href="http://proxyfor.local/proxyfor-ca-cert.pem">proxyfor-ca-cert.pem</a></p>
+<h3 id="firefox-1">Firefox</h3>
+<ol type="1">
+<li>Open Options -&gt; Privacy &amp; Security and click View
+Certificates… at the bottom of the page.</li>
+<li>Click Import… and select the downloaded certificate.</li>
+<li>Enable Trust this CA to identify websites and click OK.</li>
+</ol>

--- a/assets/install-certificate.md
+++ b/assets/install-certificate.md
@@ -35,7 +35,7 @@ summary:before {
 
 ### Manual Installation
 
-1.  Double-click the cer file to start the import wizard.
+1.  Double-click the CER file to start the import wizard.
 2.  Select a certificate store location. This determines who will trust the certificate – only the current Windows user or everyone on the machine. Click Next.
 3.  Click Next again.
 4.  Leave Password blank and click Next.

--- a/assets/install-certificate.md
+++ b/assets/install-certificate.md
@@ -1,0 +1,145 @@
+# Install proxyfor's Certificate Authority
+<!-- <head>
+    <title>proxyfor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head> -->
+
+<!-- <style>
+summary {
+    display: flex;
+    align-items: center;
+}
+summary * {
+    margin: 0;
+    padding: 0;
+}
+
+summary::-webkit-details-marker {
+    display: none;
+}
+
+summary:before {
+    content: '►';
+    display: inline-block;
+    margin-right: 5px;
+}
+</style> -->
+
+<details>
+<summary>
+
+## Windows
+</summary>
+
+[proxyfor-ca-cert.cer](http://proxyfor.local/proxyfor-ca-cert.cer)
+
+### Manual Installation
+
+1.  Double-click the cer file to start the import wizard.
+2.  Select a certificate store location. This determines who will trust the certificate – only the current Windows user or everyone on the machine. Click Next.
+3.  Click Next again.
+4.  Leave Password blank and click Next.
+5.  **Select Place all certificates in the following store**, then click Browse, and select Trusted Root Certification Authorities.  
+    Click OK and Next.
+6.  Click Finish.
+7.  Click Yes to confirm the warning dialog.
+
+### Automated Installation
+
+1.  Run `certutil.exe -addstore root proxyfor-ca-cert.cer` ([details](https://technet.microsoft.com/en-us/library/cc732443.aspx)).
+
+</details>
+
+<details>
+<summary>
+
+## Linux
+</summary>
+
+[proxyfor-ca-cert.pem](http://proxyfor.local/proxyfor-ca-cert.pem)
+
+### Ubuntu/Debian
+
+1.  `mv proxyfor-ca-cert.pem /usr/local/share/ca-certificates/proxyfor.crt`
+2.  `sudo update-ca-certificates`
+
+### Fedora
+
+1.  `mv proxyfor-ca-cert.pem /etc/pki/ca-trust/source/anchors/`
+2.  `sudo update-ca-trust`
+
+</details>
+
+<details>
+<summary>
+
+## macOS
+</summary>
+
+[proxyfor-ca-cert.pem](http://proxyfor.local/proxyfor-ca-cert.pem)
+
+### Manual Installation
+
+1.  Double-click the PEM file to open the Keychain Access application.
+2.  Locate the new certificate "proxyfor" in the list and double-click it.
+3.  Change Secure Socket Layer (SSL) to Always Trust.
+4.  Close the dialog window and enter your password if prompted.
+
+### Automated Installation
+
+1.  `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain proxyfor-ca-cert.pem`
+
+</details>
+
+<details>
+<summary>
+
+## iOS
+</summary>
+
+[proxyfor-ca-cert.pem](http://proxyfor.local/proxyfor-ca-cert.pem)
+
+### iOS 13+
+
+1.  Use Safari to download the certificate. Other browsers may not open the proper installation prompt.
+2.  Install the new Profile (Settings -> General -> VPN & Device Management).
+3.  **Important: Go to Settings -> General -> About -> Certificate Trust Settings.** Toggle proxyfor to ON.
+
+</details>
+
+<details>
+<summary>
+
+## Android
+</summary>
+
+[proxyfor-ca-cert.cer](http://proxyfor.local/proxyfor-ca-cert.cer)
+
+### Android 10+
+
+1.  Open the downloaded CER file.
+2.  Enter proxyfor (or anything else) as the certificate name.
+3.  For credential use, select VPN and apps.
+4.  Click OK.
+
+Some Android distributions require you to install the certificate via Settings -> Security -> Advanced -> Encryption and credentials -> Install a certificate -> CA certificate (or similar) instead.
+
+**Warning:** Apps that target Android API Level 24 (introduced in 2016) and above only accept certificates from the system trust store ([#2054](https://github.com/proxyfor/proxyfor/issues/2054)). User-added CAs are not accepted unless the application manually opts in. Except for browsers, you need to patch most apps manually ([Android network security config](https://developer.android.com/training/articles/security-config)).
+
+Alternatively, if you have rooted the device and have Magisk installed, you can install [this Magisk module](/cert/magisk) via the Magisk Manager app.
+
+</details>
+
+<details>
+<summary>
+
+## Firefox
+</summary>
+
+[proxyfor-ca-cert.pem](http://proxyfor.local/proxyfor-ca-cert.pem)
+
+### Firefox
+
+1.  Open Options -> Privacy & Security and click View Certificates... at the bottom of the page.
+2.  Click Import... and select the downloaded certificate.
+3.  Enable Trust this CA to identify websites and click OK.

--- a/assets/md2html.sh
+++ b/assets/md2html.sh
@@ -1,0 +1,2 @@
+pandoc assets/install-certificate.md -o assets/install-certificate.html
+sed -i -e 's|<!-- ||' -e 's| -->||' assets/install-certificate.html

--- a/src/certificate_authority.rs
+++ b/src/certificate_authority.rs
@@ -92,6 +92,10 @@ impl CertificateAuthority {
         }
     }
 
+    pub fn ca_cert_pem(&self) -> String {
+        self.ca_cert.pem()
+    }
+
     pub async fn gen_server_config(&self, authority: &Authority) -> Result<Arc<ServerConfig>> {
         if let Some(server_cfg) = self.cache.get(authority).await {
             return Ok(server_cfg);


### PR DESCRIPTION
By far the easiest way to install the proxyfor CA certificate is to use the built-in certificate installation app.
To do this, start mitmproxy and configure your target device with the correct proxy settings.
Now start a browser on the device, and visit the magic domain [proxyfor.local](http://proxyfor.local).

![proxyfor.local](https://github.com/sigoden/proxyfor/assets/4012553/a5276872-8ab1-4794-9e97-ac7038ca5e4a)